### PR TITLE
migrations to convert to the new data structure

### DIFF
--- a/migrations/001_modify_available_topics.go
+++ b/migrations/001_modify_available_topics.go
@@ -1,3 +1,5 @@
+// +build ignore
+
 /**
  * In the command line
  *

--- a/migrations/001_modify_available_topics.go
+++ b/migrations/001_modify_available_topics.go
@@ -1,0 +1,127 @@
+/**
+ * In the command line
+ *
+ * ```sh
+ * MONGODB_URL=mongodb://localhost:27017/notifications_testing go run 001_modify_available_topics.go
+ * ```
+ *
+ * `MONGODB_URL` env varilable is not needed if you are running on local, but
+ * this can be used to connect to different environments
+ */
+
+/**
+ * What does this do?
+ *
+ * - Adds `channels` array to `topics_available` collection
+ * - Adds `value` property to `topics` collection which determines if the
+ * 	 setting is a `default` one on an org level
+ */
+
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
+)
+
+const (
+	availableCollection = "topics_available"
+	topicsCollection    = "topics"
+)
+
+/**
+ * Main
+ */
+
+func main() {
+	session, db := Connect()
+	MigrateAvailable(db)
+	MigrateTopics(db)
+	session.Close()
+	fmt.Println("\n", "Closing mongodb connection")
+}
+
+/**
+ * Connect to mongo
+ */
+
+func Connect() (*mgo.Session, *mgo.Database) {
+	uri := os.Getenv("MONGODB_URL")
+
+	if uri == "" {
+		uri = "mongodb://localhost:27017/notifications_testing"
+	}
+
+	mInfo, err := mgo.ParseURL(uri)
+	session, err := mgo.Dial(uri)
+	if err != nil {
+		fmt.Printf("Can't connect to mongo, go error %v\n", err)
+		os.Exit(1)
+	}
+	session.SetSafe(&mgo.Safe{})
+	fmt.Println("Connected to", uri, "\n")
+
+	sess := session.Clone()
+
+	return session, sess.DB(mInfo.Database)
+}
+
+/**
+ * Migrate Available
+ */
+
+func MigrateAvailable(db *mgo.Database) (err error) {
+	Available := db.C(availableCollection)
+
+	change, err := Available.UpdateAll(
+		bson.M{},
+		bson.M{
+			"$set": bson.M{
+				"channels": []string{"email", "web", "push"},
+			},
+		},
+	)
+	handle_errors(err)
+	fmt.Println("Updated", change.Updated, "documents in `", availableCollection, "` collection")
+	return
+}
+
+/**
+ * Migrate Topics
+ */
+
+func MigrateTopics(db *mgo.Database) (err error) {
+	Topics := db.C(topicsCollection)
+
+	change, err := Topics.UpdateAll(
+		bson.M{
+			"user": "",
+			"org": bson.M{
+				"$ne": "",
+			},
+		},
+		bson.M{
+			"$set": bson.M{
+				"value": true,
+			},
+		},
+	)
+	handle_errors(err)
+	fmt.Println("Updated", change.Updated, "documents in `", topicsCollection, "` collection")
+	return
+}
+
+/**
+ * Handle errors
+ */
+
+func handle_errors(err error) {
+	if err != nil {
+		log.Printf("Error %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/migrations/002_add_defaults_locks_to_topics.go
+++ b/migrations/002_add_defaults_locks_to_topics.go
@@ -1,0 +1,132 @@
+/**
+ * In the command line
+ *
+ * ```sh
+ * MONGODB_URL=mongodb://localhost:27017/notifications_testing go run 002_add_defaults_locks_to_topics.go
+ * ```
+ *
+ * `MONGODB_URL` env varilable is not needed if you are running on local, but
+ * this can be used to connect to different environments
+ */
+
+/**
+ * What does this do?
+ *
+ * - Remove `app_name` property from `topics` collection
+ * - Remove previously added `value` property to `topics` collection
+ * - Modify `channels` property in `topics` collection from array of strings
+ *   to array of objects
+ */
+
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
+)
+
+const (
+	availableCollection = "topics_available"
+	topicsCollection    = "topics"
+)
+
+/**
+ * Main
+ */
+
+func main() {
+	session, db := Connect()
+	RemoveAppName(db)
+	RemoveValue(db)
+	ModifyChannels(db)
+	session.Close()
+	fmt.Println("\n", "Closing mongodb connection")
+}
+
+/**
+ * Connect to mongo
+ */
+
+func Connect() (*mgo.Session, *mgo.Database) {
+	uri := os.Getenv("MONGODB_URL")
+
+	if uri == "" {
+		uri = "mongodb://localhost:27017/notifications_testing"
+	}
+
+	mInfo, err := mgo.ParseURL(uri)
+	session, err := mgo.Dial(uri)
+	if err != nil {
+		fmt.Printf("Can't connect to mongo, go error %v\n", err)
+		os.Exit(1)
+	}
+	session.SetSafe(&mgo.Safe{})
+	fmt.Println("Connected to", uri, "\n")
+
+	sess := session.Clone()
+
+	return session, sess.DB(mInfo.Database)
+}
+
+/**
+ * Remove `app_name` from `topics` collection
+ */
+
+func RemoveAppName(db *mgo.Database) (err error) {
+	Topics := db.C(topicsCollection)
+
+	change, err := Topics.UpdateAll(
+		bson.M{},
+		bson.M{
+			"$unset": bson.M{
+				"app_name": "",
+			},
+		},
+	)
+	handle_errors(err)
+	fmt.Println("Updated", change.Updated, "documents in `", topicsCollection, "` collection")
+	return
+}
+
+/**
+ * Remove `value` from `topics` collection
+ */
+
+func RemoveValue(db *mgo.Database) (err error) {
+	Topics := db.C(topicsCollection)
+
+	change, err := Topics.UpdateAll(
+		bson.M{},
+		bson.M{
+			"$unset": bson.M{
+				"value": "",
+			},
+		},
+	)
+	handle_errors(err)
+	fmt.Println("Updated", change.Updated, "documents in `", topicsCollection, "` collection")
+	return
+}
+
+/**
+ * Modify channels array in `topics` collection
+ */
+
+func ModifyChannels(db *mgo.Database) (err error) {
+
+}
+
+/**
+ * Handle errors
+ */
+
+func handle_errors(err error) {
+	if err != nil {
+		log.Printf("Error %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/migrations/002_add_defaults_locks_to_topics.go
+++ b/migrations/002_add_defaults_locks_to_topics.go
@@ -1,3 +1,5 @@
+// +build ignore
+
 /**
  * In the command line
  *

--- a/migrations/002_add_defaults_locks_to_topics.go
+++ b/migrations/002_add_defaults_locks_to_topics.go
@@ -16,6 +16,8 @@
  * - Remove previously added `value` property to `topics` collection
  * - Modify `channels` property in `topics` collection from array of strings
  *   to array of objects
+ * - Rename locks collection to `temp_locks`
+ * - Rename defaults collection to `temp_defaults`
  */
 
 package main

--- a/migrations/README.md
+++ b/migrations/README.md
@@ -1,0 +1,8 @@
+These migrations are currently run manually. The latest one needs to be run if there are any changes to the data structure in the database.
+
+Don't forget to include the migration script with your PR.
+
+Todo:
+
+- [ ] Use a migration tool like [mattes/migrate](https://github.com/mattes/migrate)
+


### PR DESCRIPTION
Run·

```sh
$ MONGODB_URL=mongodb://... go run migrations/002_add_defaults_locks_to_topics.go
```

I plan to add support for github.com/mattes/migrate later.

Running the above will 

- Rename defaults and locks collection to temp_defaults and temp_locks. This can be removed later if everything goes well
- Modifies channels property from array of strings to array of documents
- Removes value attribute that was added in the previous migration
- Removes app_name attribute from topics collection