### PR TITLE
Feature/fix khabar

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -7,6 +7,10 @@
 			"Rev": "c2d3050044d05357eaf6c3547249ba57c5e235cb"
 		},
 		{
+			"ImportPath": "github.com/jinzhu/copier",
+			"Rev": "b0be9dc6538c1c9029d6baedfc06247b37f077fa"
+		},
+		{
 			"ImportPath": "github.com/nicksnyder/go-i18n/i18n",
 			"Comment": "v1.3.0-5-g37e5c2d",
 			"Rev": "37e5c2de3e03e4b82693e3fcb4a6aa2cc4eb07e3"

--- a/core/sender.go
+++ b/core/sender.go
@@ -108,7 +108,7 @@ func getText(locale, ident, channel string, pending_item *db.PendingItem) string
 
 // getCategories fetchs distinct available categories to which we can send notifications
 func getCategories() []string {
-	session := db.Conn.Session().Copy()
+	session := db.Conn.Session.Copy()
 	defer session.Close()
 
 	var categories []string

--- a/core/sender.go
+++ b/core/sender.go
@@ -15,6 +15,7 @@ import (
 	"github.com/bulletind/khabar/dbapi/processed"
 	"github.com/bulletind/khabar/dbapi/topics"
 	"github.com/bulletind/khabar/utils"
+	"github.com/jinzhu/copier"
 	"github.com/nicksnyder/go-i18n/i18n"
 	"gopkg.in/mgo.v2/bson"
 )
@@ -243,18 +244,24 @@ func ProcessDefaults(user, org string) {
 func SendNotification(pending_item *db.PendingItem) {
 	ProcessDefaults(pending_item.User, pending_item.Organization)
 
+	locale := getLocale(pending_item)
+
 	childwg := new(sync.WaitGroup)
 
 	for channel, _ := range ChannelMap {
 		childwg.Add(1)
+
+		// create copy so parallel processes can alter the item
+		var itemToSend *db.PendingItem
+		copier.Copy(pending_item, itemToSend)
 
 		go func(
 			language, channelIdent string,
 			pending_item *db.PendingItem,
 		) {
 			defer childwg.Done()
-			send(language, channelIdent, pending_item)
-		}(getLocale(pending_item), channel, pending_item)
+			send(language, channelIdent, itemToSend)
+		}(locale, channel, itemToSend)
 	}
 
 	childwg.Wait()

--- a/core/sender_test.go
+++ b/core/sender_test.go
@@ -26,7 +26,7 @@ func setup() {
 		Channels: []string{"email", "web", "push"},
 	}
 	available.PrepareSave()
-	err := db.Conn.Session().DB(dbName).C(db.AvailableTopicCollection).Insert(available)
+	err := db.Conn.Session.DB(dbName).C(db.AvailableTopicCollection).Insert(available)
 	if err != nil {
 		t.Error("Unable to setup db for testing")
 	}
@@ -67,5 +67,5 @@ func TestGetEmailKeys(t *testing.T) {
 }
 
 func cleanup() {
-	db.Conn.Session().DB(dbName).DropDatabase()
+	db.Conn.Session.DB(dbName).DropDatabase()
 }

--- a/db/conn.go
+++ b/db/conn.go
@@ -18,17 +18,9 @@ import (
 var Conn *MConn
 
 type MConn struct {
-	session    *mgo.Session
+	Session    *mgo.Session
 	Dbname     string
 	ConnString string
-}
-
-func (self MConn) Session() *mgo.Session {
-	if self.session == nil {
-		log.Println("Forced to renew session, investigate why!")
-		self.session = getNewSession(self.ConnString, self.Dbname)
-	}
-	return self.session
 }
 
 func (self *MConn) getCursor(session *mgo.Session, table string,
@@ -66,7 +58,7 @@ func (self *MConn) findAndApply(
 	table string, query utils.M, change mgo.Change, result interface{},
 ) (*mgo.ChangeInfo, error) {
 	//Create a Session Copy and be responsible for Closing it.
-	session := self.Session().Copy()
+	session := self.Session.Copy()
 	db := session.DB(self.Dbname)
 	defer session.Close()
 
@@ -108,7 +100,7 @@ func (self *MConn) Get(session *mgo.Session, table string,
 func (self *MConn) GetOne(table string, query utils.M,
 	result interface{}) error {
 	//Create a Session Copy and be responsible for Closing it.
-	session := self.Session().Copy()
+	session := self.Session.Copy()
 	defer session.Close()
 
 	cursor := self.getCursor(session, table, query)
@@ -124,12 +116,12 @@ func (self *MConn) Count(table string, query utils.M) int {
 	if self == nil {
 		log.Println("self is nil, investigate why!")
 	}
-	if self.Session() == nil {
+	if self.Session == nil {
 		log.Println("self.Session() is nil, investigate why!")
 	}
 
 	//Create a Session Copy and be responsible for Closing it.
-	session := self.Session().Copy()
+	session := self.Session.Copy()
 	defer session.Close()
 
 	cursor := self.getCursor(session, table, query).Select(utils.M{"_id": 1})
@@ -144,7 +136,7 @@ func (self *MConn) Count(table string, query utils.M) int {
 func (self *MConn) Upsert(table string, query utils.M, doc utils.M) error {
 
 	//Create a Session Copy and be responsible for Closing it.
-	session := self.Session().Copy()
+	session := self.Session.Copy()
 	db := session.DB(self.Dbname)
 	defer session.Close()
 
@@ -179,7 +171,7 @@ func AlterDoc(doc *utils.M, operator string, operation utils.M) {
 func (self *MConn) Update(table string, query utils.M, doc utils.M) error {
 
 	//Create a Session Copy and be responsible for Closing it.
-	session := self.Session().Copy()
+	session := self.Session.Copy()
 	db := session.DB(self.Dbname)
 	defer session.Close()
 
@@ -203,7 +195,7 @@ func (self *MConn) Update(table string, query utils.M, doc utils.M) error {
 
 func (self *MConn) Delete(table string, query utils.M) error {
 	//Create a Session Copy and be responsible for Closing it.
-	session := self.Session().Copy()
+	session := self.Session.Copy()
 	db := session.DB(self.Dbname)
 	defer session.Close()
 
@@ -232,7 +224,7 @@ func InArray(key string, arrays ...[]string) bool {
 }
 
 func (self *MConn) InsertMulti(table string, arguments ...interface{}) (error, *mgo.BulkResult) {
-	session := self.Session().Copy()
+	session := self.Session.Copy()
 	db := session.DB(self.Dbname)
 	defer session.Close()
 
@@ -247,7 +239,7 @@ func (self *MConn) InsertMulti(table string, arguments ...interface{}) (error, *
 
 func (self *MConn) Insert(table string, arguments ...interface{}) (_id string) {
 	//Create a Session Copy and be responsible for Closing it.
-	session := self.Session().Copy()
+	session := self.Session.Copy()
 	db := session.DB(self.Dbname)
 	defer session.Close()
 

--- a/db/conn.go
+++ b/db/conn.go
@@ -113,13 +113,6 @@ func (self *MConn) GetOne(table string, query utils.M,
 }
 
 func (self *MConn) Count(table string, query utils.M) int {
-	if self == nil {
-		log.Println("self is nil, investigate why!")
-	}
-	if self.Session == nil {
-		log.Println("self.Session() is nil, investigate why!")
-	}
-
 	//Create a Session Copy and be responsible for Closing it.
 	session := self.Session.Copy()
 	defer session.Close()

--- a/dbapi/available_topics/dbapi.go
+++ b/dbapi/available_topics/dbapi.go
@@ -16,7 +16,7 @@ type ChotaTopic map[string]*TopicDetail
 
 // GetAllTopics returns all the available topics
 func GetAllTopics() []string {
-	session := db.Conn.Session().Copy()
+	session := db.Conn.Session.Copy()
 	defer session.Close()
 
 	topics := []string{}
@@ -30,7 +30,7 @@ func GetAllTopics() []string {
 
 // GetAppTopics returns all the available topics for the particular app
 func GetAppTopics(app_name, org string) (*[]db.AvailableTopic, error) {
-	session := db.Conn.Session().Copy()
+	session := db.Conn.Session.Copy()
 	defer session.Close()
 
 	query := utils.M{"app_name": app_name}
@@ -64,7 +64,7 @@ func GetOrgPreferences(org string, appTopics *[]db.AvailableTopic, channels *[]s
 
 	topic := new(db.Topic)
 
-	session := db.Conn.Session().Copy()
+	session := db.Conn.Session.Copy()
 	defer session.Close()
 
 	for _, topic := range *appTopics {
@@ -135,7 +135,7 @@ func GetUserPreferences(user, org string, appTopics *[]db.AvailableTopic, channe
 
 	topic := new(db.Topic)
 
-	session := db.Conn.Session().Copy()
+	session := db.Conn.Session.Copy()
 	defer session.Close()
 
 	for _, topic := range *appTopics {

--- a/dbapi/saved_item/dbapi.go
+++ b/dbapi/saved_item/dbapi.go
@@ -23,7 +23,7 @@ func Get(coll string, query *utils.M) (savedItem *db.SavedItem, err error) {
 }
 
 func GetSentOrganizations(coll string, email string) (string, []string) {
-	session := db.Conn.Session().Copy()
+	session := db.Conn.Session.Copy()
 	defer session.Close()
 
 	orgs := []string{}

--- a/dbapi/sent/dbapi.go
+++ b/dbapi/sent/dbapi.go
@@ -70,7 +70,7 @@ func GetAll(paginator *gottp.Paginator, user, appName, org string) (*[]db.SentIt
 	delete(query, "limit")
 	delete(query, "skip")
 
-	session := db.Conn.Session().Copy()
+	session := db.Conn.Session.Copy()
 	defer session.Close()
 
 	err := db.Conn.GetCursor(session, db.SentCollection,

--- a/dbapi/topics/dbapi.go
+++ b/dbapi/topics/dbapi.go
@@ -174,7 +174,7 @@ func Initialize(user, org string) error {
 
 // GetAllDefault returns all the "default - non-enabled" preferences for the organization
 func GetAllDefault(org string) []db.Topic {
-	session := db.Conn.Session().Copy()
+	session := db.Conn.Session.Copy()
 	defer session.Close()
 
 	result := []db.Topic{}
@@ -219,7 +219,7 @@ func ChannelAllowed(user, org, app_name, ident, channelName string) bool {
 }
 
 func DisableUserChannel(orgs, topics []string, user, channelName string) {
-	session := db.Conn.Session().Copy()
+	session := db.Conn.Session.Copy()
 	defer session.Close()
 
 	utils.RemoveDuplicates(&orgs)

--- a/vendor/github.com/jinzhu/copier/Guardfile
+++ b/vendor/github.com/jinzhu/copier/Guardfile
@@ -1,0 +1,3 @@
+guard 'gotest' do
+  watch(%r{\.go$})
+end

--- a/vendor/github.com/jinzhu/copier/License
+++ b/vendor/github.com/jinzhu/copier/License
@@ -1,0 +1,20 @@
+The MIT License (MIT)
+
+Copyright (c) 2015 Jinzhu
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/vendor/github.com/jinzhu/copier/README.md
+++ b/vendor/github.com/jinzhu/copier/README.md
@@ -1,0 +1,77 @@
+# Copier
+
+  I am a copier, I copy everything from a struct to another struct
+
+## Features
+
+* Copy field to field if name exactly match
+* Copy from method to field if method name and field name exactly match
+* Copy from field to method if field name and method name exactly match
+* Copy slice to slice
+* Copy struct to slice
+
+## Usage
+
+```go
+import . "github.com/jinzhu/copier"
+
+type User struct {
+	Name string
+	Role string
+	Age  int32
+}
+
+func (user *User) DoubleAge() int32 {
+	return 2 * user.Age
+}
+
+type Employee struct {
+	Name      string
+	Age       int32
+	DoubleAge int32
+	EmployeId int64
+	SuperRule string
+}
+
+func (employee *Employee) Role(role string) {
+	employee.SuperRule = "Super " + role
+}
+
+user := User{Name: "Jinzhu", Age: 18, Role: "Admin"}
+employee := Employee{}
+
+Copy(&employee, &user)
+
+// employee => Employee{ Name: "Jinzhu",           // Copy from field
+//                       Age: 18,                  // Copy from field
+//                       DoubleAge: 36,            // Copy from method
+//                       EmployeeId: 0,            // Just ignored
+//                       SuperRule: "Super Admin", // Copy to method
+//                      }
+
+// Copy struct to slice
+user := User{Name: "hello", Age: 18, Role: "User"}
+employees := []Employee{}
+Copy(&employees, &user)
+// employees => [{hello 18 0 36 Super User}]
+
+
+// Copy slice to slice
+users := []User{{Name: "Jinzhu", Age: 18, Role: "Admin"}, {Name: "jinzhu 2", Age: 30, Role: "Dev"}}
+employees := []Employee{}
+Copy(&employees, &users)
+
+// employees => [{hello 18 0 36 Super User} {Jinzhu 18 0 36 Super Admin} {jinzhu 2 30 0 60 Super Dev}]
+```
+
+# Author
+
+**jinzhu**
+
+* <http://github.com/jinzhu>
+* <wosmvp@gmail.com>
+* <http://twitter.com/zhangjinzhu>
+
+## License
+
+Released under the [MIT License](https://github.com/jinzhu/copier/blob/master/License).

--- a/vendor/github.com/jinzhu/copier/copier.go
+++ b/vendor/github.com/jinzhu/copier/copier.go
@@ -1,0 +1,120 @@
+package copier
+
+import "reflect"
+
+func Copy(toValue interface{}, fromValue interface{}) (err error) {
+	var (
+		isSlice   bool
+		fromType  reflect.Type
+		isFromPtr bool
+		toType    reflect.Type
+		isToPtr   bool
+		amount    int
+	)
+
+	from := reflect.Indirect(reflect.ValueOf(fromValue))
+	to := reflect.Indirect(reflect.ValueOf(toValue))
+
+	if to.Kind() == reflect.Slice {
+		isSlice = true
+		if from.Kind() == reflect.Slice {
+			fromType = from.Type().Elem()
+			if fromType.Kind() == reflect.Ptr {
+				fromType = fromType.Elem()
+				isFromPtr = true
+			}
+			amount = from.Len()
+		} else {
+			fromType = from.Type()
+			amount = 1
+		}
+
+		toType = to.Type().Elem()
+		if toType.Kind() == reflect.Ptr {
+			toType = toType.Elem()
+			isToPtr = true
+		}
+	} else {
+		fromType = from.Type()
+		toType = to.Type()
+		amount = 1
+	}
+
+	for e := 0; e < amount; e++ {
+		var dest, source reflect.Value
+		if isSlice {
+			if from.Kind() == reflect.Slice {
+				source = from.Index(e)
+				if isFromPtr {
+					source = source.Elem()
+				}
+			} else {
+				source = from
+			}
+		} else {
+			source = from
+		}
+
+		if isSlice {
+			dest = reflect.New(toType).Elem()
+		} else {
+			dest = to
+		}
+
+		for _, field := range deepFields(fromType) {
+			if !field.Anonymous {
+				name := field.Name
+				fromField := source.FieldByName(name)
+				toField := dest.FieldByName(name)
+				toMethod := dest.Addr().MethodByName(name)
+				if fromField.IsValid() && toField.IsValid() && toField.CanSet() {
+					toField.Set(fromField)
+				}
+
+				if fromField.IsValid() && toMethod.IsValid() {
+					toMethod.Call([]reflect.Value{fromField})
+				}
+			}
+		}
+
+		for i := 0; i < toType.NumField(); i++ {
+			field := toType.Field(i)
+			if !field.Anonymous {
+				name := field.Name
+				fromMethod := source.Addr().MethodByName(name)
+				toField := dest.FieldByName(name)
+
+				if fromMethod.IsValid() && toField.IsValid() && toField.CanSet() {
+					values := fromMethod.Call([]reflect.Value{})
+					if len(values) >= 1 {
+						toField.Set(values[0])
+					}
+				}
+			}
+		}
+
+		if isSlice {
+			if isToPtr {
+				to.Set(reflect.Append(to, dest.Addr()))
+			} else {
+				to.Set(reflect.Append(to, dest))
+			}
+		}
+	}
+	return
+}
+
+func deepFields(ifaceType reflect.Type) []reflect.StructField {
+	var fields []reflect.StructField
+
+	for i := 0; i < ifaceType.NumField(); i++ {
+		v := ifaceType.Field(i)
+		if v.Anonymous && v.Type.Kind() == reflect.Struct {
+			fields = append(fields, deepFields(v.Type)...)
+		} else {
+			fields = append(fields, v)
+		}
+	}
+
+	return fields
+}


### PR DESCRIPTION
As we had some crashes, we had to find out why. It turns out Go crashed due to writing to a map by different threads.

https://github.com/bulletind/khabar/blob/develop/core/sender.go#L243 creates a goroutine per channel. In line https://github.com/bulletind/khabar/blob/develop/core/sender.go#L204 the subject was altered. To prevent this, we create a copy of the pending_item per newly created thread.

Also, the previous added 'Session()' function is no longer needed.